### PR TITLE
ignore PRs on heroku-pages branch of private-www

### DIFF
--- a/hooks/private_www_build_test.py
+++ b/hooks/private_www_build_test.py
@@ -52,6 +52,10 @@ def process_payload(payload, meta, config):
         logging.debug("Skipping private-www build test: this is not opening/updating a PR")
         return
 
+    if payload['master_branch']=='heroku-pages':
+        logging.debug("Skipping private-www build test because PR is based on heroku-pages branch")
+        return
+
     # Keep it simple:
     # get the head commit
     head_commit = payload['pull_request']['head']['sha']


### PR DESCRIPTION
Modifies the private-www pull request build script, which builds the mkdocs from the master branch, so that it ignores any PRs based on the heroku-pages branch (which is a totally separate branch with no mkdocs content).

Closes #14.