### PR TITLE
fix submodule name. closes #21

### DIFF
--- a/hooks/private_www_update_submodules.py
+++ b/hooks/private_www_update_submodules.py
@@ -211,7 +211,11 @@ def process_payload(payload, meta, config):
 
     if not abort:
 
-        submodule_dir_relative = os.path.join('docs', repo_name)
+        if repo_name == 'dcppc-workshops':
+            submodule_dir_relative = os.path.join('docs','workshops')
+        else:
+            submodule_dir_relative = os.path.join('docs', repo_name)
+
         submodule_dir = os.path.join(repo_dir, submodule_dir_relative)
 
         subcocmd = ['git','checkout','master']


### PR DESCRIPTION
Fix the name of the workshops submodule in the private-www submodule update hook. Instead of looking for `private-www/docs/dcppc-workshops`, look for `private-www/docs/workshops`.

- [x] this PR is ready to merge