### PR TITLE
add hosting of htdocs directory during private www build tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.htpasswd
 __pycache__
 site/
 config.json

--- a/hooks/private_www_build_test.py
+++ b/hooks/private_www_build_test.py
@@ -194,9 +194,8 @@ def process_payload(payload, meta, config):
     # end snakemake build
     # -----------------------------------------------
 
-    status_url_base = "https://archie.nihdatacommons.us/output/"
-    status_url_log = "https://archie.nihdatacommons.us/output/%s"%(status_file)
-    status_url_www = "https://archie.nihdatacommons.us/output/%s"%(htdocs_dir)
+    status_url_log = "https://archie.nihdatacommons.us/output/log/%s"%(status_file)
+    status_url_www = "https://archie.nihdatacommons.us/output/htdocs/%s"%(htdocs_dir)
 
     
     if build_status == "pass":
@@ -206,20 +205,22 @@ def process_payload(payload, meta, config):
         if htdocs_msg == "":
             htdocs_msg = params['htdocs_pass_msg']
 
+        # build task status 
         try:
             commit_status = c.create_status(
                             state = "success",
-                            target_url = status_url,
+                            target_url = status_url_log,
                             description = build_msg,
                             context = params['build_task_name']
             )
         except GithubException as e:
             logging.info("Github error: commit status failed to update.")
 
+        # htdocs hosting task status 
         try:
             commit_status = c.create_status(
                             state = "success",
-                            target_url = status_url,
+                            target_url = status_url_www,
                             description = htdocs_msg,
                             context = params['htdocs_task_name']
             )
@@ -265,8 +266,11 @@ def serve_htdocs_output(cwd_dir,unique_htdocs):
     Given a folder name unique_htdocs containing
     the htdocs directory from this mkdocs run,
     """
-    output_path = os.path.join(HTDOCS,'output')
+    output_path = os.path.join(HTDOCS,'output','htdocs')
     output_file = os.path.join(output_path,unique_htdocs)
+
+    if not os.path.exists(output_path):
+        os.mkdir(output_path)
 
     try:
         subprocess.call(['mv','site',output_file],
@@ -294,8 +298,11 @@ def record_and_check_output(proc,label,unique_filename):
     status_failed       Boolean: did status fail?
     status_file         String: filename where log is located
     """ 
-    output_path = os.path.join(HTDOCS,'output')
+    output_path = os.path.join(HTDOCS,'output','logs')
     output_file = os.path.join(output_path,unique_filename)
+
+    if not os.path.exists(output_path):
+        os.mkdir(output_path)
 
     out = proc.stdout.read().decode('utf-8')
     err = proc.stderr.read().decode('utf-8')

--- a/hooks/private_www_build_test.py
+++ b/hooks/private_www_build_test.py
@@ -18,6 +18,9 @@ Otherwise the commit is marked as failed.
 
 HTDOCS="/www/archie.nihdatacommons.us/htdocs"
 
+OUTPUT_LOGS="output/logs"
+OUTPUT_HTDOCS="output/htdocs"
+
 def process_payload(payload, meta, config):
     """
     Look for events that are pull requests being opened or updated. 
@@ -290,7 +293,7 @@ def serve_htdocs_output(cwd_dir,unique_htdocs):
     Given a folder name unique_htdocs containing
     the htdocs directory from this mkdocs run,
     """
-    output_path = os.path.join(HTDOCS,'output','htdocs')
+    output_path = os.path.join(HTDOCS,OUTPUT_HTDOCS)
     output_file = os.path.join(output_path,unique_htdocs)
 
     if not os.path.exists(output_path):
@@ -326,7 +329,7 @@ def record_and_check_output(proc,label,unique_filename,ignore_text=None):
     status_failed       Boolean: did status fail?
     status_file         String: filename where log is located
     """ 
-    output_path = os.path.join(HTDOCS,'output','logs')
+    output_path = os.path.join(HTDOCS,OUTPUT_LOGS)
     output_file = os.path.join(output_path,unique_filename)
 
     if not os.path.exists(output_path):

--- a/nginx/archie.conf
+++ b/nginx/archie.conf
@@ -31,6 +31,7 @@ server {
                       application/atom+xml;
 
     root /www/archie.nihdatacommons.us/htdocs;
+    index index.html index.htm;
 
     #################################
     # This section makes root url / into
@@ -42,19 +43,10 @@ server {
 
 
     #################################
-    # This section makes build logs
-    # available to anyone
-
-    location /output/logs {
-        try_files $uri $uri/ =404;
-    }
-
-
-    #################################
     # This section makes hosted mkdocs
     # sites available behind an auth layer
 
-    location /output/htdocs {
+    location /output/htdocs/ {
         try_files $uri $uri/ =404;
         auth_basic "Access-restricted content: DCPPC members only (check Uncle Archie status for username/password)";
         auth_basic_user_file /etc/nginx/.htpasswd;
@@ -67,7 +59,7 @@ server {
     # via reverse proxy on local port 5005
 
     location /webhook {
-        # /webhook* anything takes user to port 5005, api
+        # This matches /webhook exactly
         proxy_set_header   X-Real-IP  $remote_addr;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   Host $host;

--- a/nginx/archie.conf
+++ b/nginx/archie.conf
@@ -30,19 +30,41 @@ server {
                       application/x-javascript
                       application/atom+xml;
 
-    #################
-    # This section is not necessary,
-    # it makes the root url / into a 
-    # static hosted site
-
     root /www/archie.nihdatacommons.us/htdocs;
+
+    #################################
+    # This section makes root url / into
+    # a static hosted site (useful)
 
     location / {
         try_files $uri $uri/ =404;
     }
 
-    # now on with the show...
-    ##################
+
+    #################################
+    # This section makes build logs
+    # available to anyone
+
+    location /output/logs {
+        try_files $uri $uri/ =404;
+    }
+
+
+    #################################
+    # This section makes hosted mkdocs
+    # sites available behind an auth layer
+
+    location /output/htdocs {
+        try_files $uri $uri/ =404;
+        auth_basic "Access-restricted content: DCPPC members only (check Uncle Archie status for username/password)";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+    }
+
+
+    #################################
+    # The most important route!
+    # webhooks are passed to uncle archie
+    # via reverse proxy on local port 5005
 
     location /webhook {
         # /webhook* anything takes user to port 5005, api

--- a/scripts/make_htpasswd.sh
+++ b/scripts/make_htpasswd.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# run this script and specify a password
+# with the NGINX_PASSWORD env var
+
+
+function usage() {
+    echo ""
+    echo "make_htpasswd.sh:"
+    echo ""
+    echo "    This script creates an .htpasswd file"
+    echo "    so nginx can password-protect a directory."
+    echo ""
+    echo "    Set the nginx password using the NGINX_PASSWORD"
+    echo "    environment variable."
+    echo ""
+    echo "Usage:"
+    echo ""
+    echo "    NGINX_PASSWORD=\"<password>\" ./make_htpasswd.sh"
+    echo ""
+    exit 1;
+}
+
+
+function copy() {
+    echo ""
+    echo "Successfully output .htpasswd file in current directory."
+    echo "To use this file with nginx, place file at /etc/nginx/.htpasswd"
+    echo "and add the following lines to the appropriate nginx conf block:"
+    echo "    location / { "
+    echo "        ..."
+    echo "        auth_basic \"Restricted Content\";"
+    echo "        auth_basic_user_file /etc/nginx/.htpasswd;"
+    echo "        ..."
+    echo "    }"
+    echo ""
+    exit 1;
+}
+
+
+if [[ "${NGINX_PASSWORD}" == "" ]]; then
+    usage
+else
+    echo -n 'archie:' >> .htpasswd
+    openssl passwd -apr1 >> .htpasswd
+    if [ -f /etc/nginx/ ]; then
+        mv .htpasswd /etc/nginx/.htpasswd
+    fi
+fi
+
+

--- a/scripts/make_htpasswd.sh
+++ b/scripts/make_htpasswd.sh
@@ -22,30 +22,70 @@ function usage() {
 }
 
 
-function copy() {
+function final() {
     echo ""
-    echo "Successfully output .htpasswd file in current directory."
-    echo "To use this file with nginx, place file at /etc/nginx/.htpasswd"
-    echo "and add the following lines to the appropriate nginx conf block:"
-    echo "    location / { "
-    echo "        ..."
-    echo "        auth_basic \"Restricted Content\";"
-    echo "        auth_basic_user_file /etc/nginx/.htpasswd;"
-    echo "        ..."
-    echo "    }"
+    echo "make_htpasswd.sh:"
+    echo ""
+    echo "    Successfully output .htpasswd file in current directory."
+    echo ""
+    echo "    To use this file with nginx, place file at /etc/nginx/.htpasswd"
+    echo "    and add the following lines to the appropriate nginx conf block:"
+    echo ""
+    echo "        location / { "
+    echo "            ..."
+    echo "            auth_basic \"Restricted Content\";"
+    echo "            auth_basic_user_file /etc/nginx/.htpasswd;"
+    echo "            ..."
+    echo "        }"
     echo ""
     exit 1;
 }
 
 
+## Only run this script if you are root!
+#if [ "$(id -u)" != "0" ]; then
+#    echo ""
+#    echo ""
+#    echo "This script should be run as root."
+#    echo ""
+#    echo ""
+#    usage;
+#    exit 1;
+#fi
+
+
+# User must set NGINX_PASSWORD using environment variable
 if [[ "${NGINX_PASSWORD}" == "" ]]; then
+
+    # User is confused
     usage
+
 else
+
+    echo "+---------------------------+"
+    echo "Creating .htpasswd file..."
+    echo "STEP 1: Preparing to set username"
+
+    # Username is always "archie"
     echo -n 'archie:' >> .htpasswd
-    openssl passwd -apr1 >> .htpasswd
+
+    echo "STEP 1: Username has been set."
+    echo "STEP 2: Preparing to set password for user 'archie'."
+
+    # Password comes from env var
+    openssl passwd -apr1 ${NGINX_PASSWORD} >> .htpasswd
+
+    echo "STEP 2: Password has been set."
+    echo "STEP 3: Preparing to copy .htpasswd file into place."
+
+    # Move the .htpasswd file into place
     if [ -f /etc/nginx/ ]; then
-        mv .htpasswd /etc/nginx/.htpasswd
+        sudo mv .htpasswd /etc/nginx/.htpasswd
     fi
+
+    echo "STEP 3: .htpasswd file has been moved into place."
+
+    final
 fi
 
 

--- a/scripts/make_htpasswd.sh
+++ b/scripts/make_htpasswd.sh
@@ -66,6 +66,9 @@ else
     echo "Creating .htpasswd file..."
     echo "STEP 1: Preparing to set username"
 
+    rm -f .htpasswd
+    touch .htpasswd
+
     # Username is always "archie"
     echo -n 'archie:' >> .htpasswd
 
@@ -79,11 +82,14 @@ else
     echo "STEP 3: Preparing to copy .htpasswd file into place."
 
     # Move the .htpasswd file into place
-    if [ -f /etc/nginx/ ]; then
+    if [ -d /etc/nginx ]; then
+        echo "STEP 3: Copying .htpasswd file."
         sudo mv .htpasswd /etc/nginx/.htpasswd
+        echo "STEP 3: .htpasswd file has been moved into place."
+    else
+        echo "STEP 3: Failed to find /etc/nginx, file could not be copied."
     fi
 
-    echo "STEP 3: .htpasswd file has been moved into place."
 
     final
 fi


### PR DESCRIPTION
Add hosting of htdocs directory in addition to hosting of log directory when running private-www build tests.

We also need to add simple username/password authentication with nginx on Uncle Archie (this is in the uncle-archie repo, so that is part of this pull request). Don't involve Heroku or Github logins, use nginx and keep it simple.