### PR TITLE
remove fancy handling of already-open submodule update PRs

### DIFF
--- a/hooks/private_www_update_submodules.py
+++ b/hooks/private_www_update_submodules.py
@@ -186,341 +186,149 @@ def process_payload(payload, meta, config):
     commit_msg = '[Uncle Archie] Updating submodule %s to commit %s'%(full_sub_name,new_sha[0:7])
     pr_msg = commit_msg 
 
-    # Look for a PR containing commit_prefix
-    # If we find one, do a commit and a push
-    # If we don't find one, do a branch and a PR
+    # Make a branch and a PR 
     existing_pr_head = None
-    for pr in parent_r.get_pulls(state='open',base='master'):
-        if commit_prefix in pr.title:
-            # Get the branch name
-            head = existing_pr_head
-            # Update the title with the new commit
-            pr.edit(title = commit_msg)
-            break
-
     if existing_pr_head is not None:
 
-        # ------------------------------------
-        # Begin sync PR workflow 
+    # ------------------------------------
+    # Begin sync PR workflow 
 
-        ######################
-        # Unique branch name
-        ######################
+    ######################
+    # Unique branch name
+    ######################
 
-        # We know this is a branch in the same repo
-        # b/c, eyyy, it's me, Uncle Archie
-        branch_name = existing_pr_head
+    # We know this is a branch in the same repo
+    # b/c, eyyy, it's me, Uncle Archie
+    branch_name = existing_pr_head
 
-        ######################
-        # Check out branch 
-        ######################
+    ######################
+    # Check out branch 
+    ######################
 
-        if not abort:
+    if not abort:
 
-            repo_dir = os.path.join(scratch_dir, parent_repo_name)
+        repo_dir = os.path.join(scratch_dir, parent_repo_name)
 
-            cocmd = ['git','checkout','-b',branch_name,'origin/%s'%(branch_name)]
-            logging.debug("Running cmd: %s"%(' '.join(cocmd)))
-            coproc = subprocess.Popen(
-                    cocmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(coproc,"git checkout",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+        cocmd = ['git','checkout','-b',branch_name,'origin/%s'%(branch_name)]
+        logging.debug("Running cmd: %s"%(' '.join(cocmd)))
+        coproc = subprocess.Popen(
+                cocmd,
+                stdout=PIPE, 
+                stderr=PIPE, 
+                cwd=repo_dir
+        )
+        status_failed, status_file = record_and_check_output(coproc,"git checkout",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
-        # In case of new submodule
-        if not abort:
-            sucmd = ['git','submodule','update','--init']
-            suproc = subprocess.Popen(
-                    sucmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(suproc,"submodule update",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+    # In case of new submodule
+    if not abort:
+        sucmd = ['git','submodule','update','--init']
+        suproc = subprocess.Popen(
+                sucmd,
+                stdout=PIPE, 
+                stderr=PIPE, 
+                cwd=repo_dir
+        )
+        status_failed, status_file = record_and_check_output(suproc,"submodule update",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
-        ######################
-        # Check out the master branch of the submodule
-        # and pull the latest changes from upstream
-        ######################
+    ######################
+    # Check out the master branch of the submodule
+    # and pull the latest changes from upstream
+    ######################
 
-        if not abort:
+    if not abort:
 
-            if repo_name == 'dcppc-workshops':
-                submodule_dir_relative = os.path.join('docs','workshops')
-            else:
-                submodule_dir_relative = os.path.join('docs', repo_name)
+        if repo_name == 'dcppc-workshops':
+            submodule_dir_relative = os.path.join('docs','workshops')
+        else:
+            submodule_dir_relative = os.path.join('docs', repo_name)
 
-            submodule_dir = os.path.join(repo_dir, submodule_dir_relative)
+        submodule_dir = os.path.join(repo_dir, submodule_dir_relative)
 
-            subcocmd = ['git','checkout','master']
-            logging.debug("Running cmd: %s"%(' '.join(subcocmd)))
-            subcoproc = subprocess.Popen(
-                    subcocmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=submodule_dir
-            )
-            status_failed, status_file = record_and_check_output(subcoproc,"git checkout submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+        subcocmd = ['git','checkout','master']
+        logging.debug("Running cmd: %s"%(' '.join(subcocmd)))
+        subcoproc = subprocess.Popen(
+                subcocmd,
+                stdout=PIPE, 
+                stderr=PIPE, 
+                cwd=submodule_dir
+        )
+        status_failed, status_file = record_and_check_output(subcoproc,"git checkout submodule",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
-            pullcmd = ['git','pull','origin','master']
-            logging.debug("Running cmd: %s"%(' '.join(pullcmd)))
-            pullproc = subprocess.Popen(
-                    pullcmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=submodule_dir
-            )
-            status_failed, status_file = record_and_check_output(pullproc,"git pull submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+        pullcmd = ['git','pull','origin','master']
+        logging.debug("Running cmd: %s"%(' '.join(pullcmd)))
+        pullproc = subprocess.Popen(
+                pullcmd,
+                stdout=PIPE, 
+                stderr=PIPE, 
+                cwd=submodule_dir
+        )
+        status_failed, status_file = record_and_check_output(pullproc,"git pull submodule",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
-        ######################
-        # Add commit push the new submodule
-        ######################
+    ######################
+    # Add commit push the new submodule
+    ######################
 
-        if not abort:
+    if not abort:
 
-            # Add the submodule
-            addcmd = ['git','add',submodule_dir_relative]
-            logging.debug("Running cmd: %s"%(' '.join(addcmd)))
-            addproc = subprocess.Popen(
-                    addcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(addproc,"git add submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-
-            # Commit the new submodule
-
-            commitcmd = ['git','commit',submodule_dir_relative,'-m',commit_msg]
-            logging.debug("Running cmd: %s"%(' '.join(commitcmd)))
-            commitproc = subprocess.Popen(
-                    commitcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(commitproc,"git commit submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+        # Add the submodule
+        addcmd = ['git','add',submodule_dir_relative]
+        logging.debug("Running cmd: %s"%(' '.join(addcmd)))
+        addproc = subprocess.Popen(
+                addcmd,
+                stdout=PIPE,
+                stderr=PIPE,
+                cwd=repo_dir
+        )
+        status_failed, status_file = record_and_check_output(addproc,"git add submodule",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
 
+        # Commit the new submodule
 
-            pushcmd = ['git','push','origin',branch_name]
-            logging.debug("Running cmd: %s"%(' '.join(pushcmd)))
-            pushproc = subprocess.Popen(
-                    pushcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(pushproc,"git push origin branch",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-        # End sync PR workflow 
-        # ------------------------------------
-
-    else:
-
-        # ------------------------------------
-        # Begin open new PR workflow 
-
-        ######################
-        # Unique branch name
-        ######################
-
-        now = datetime.now().strftime("%Y%m%d_%H%M%S")
-        branch_name = "update_submodules_%s"%(now)
-
-
-        ######################
-        # Create new branch
-        # from master branch HEAD
-        ######################
-
-        if not abort:
-
-            repo_dir = os.path.join(scratch_dir, parent_repo_name)
-
-            cocmd = ['git','checkout','-b',branch_name]
-            logging.debug("Running cmd: %s"%(' '.join(cocmd)))
-            coproc = subprocess.Popen(
-                    cocmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(coproc,"git checkout",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-        # In case of new submodule
-        if not abort:
-            sucmd = ['git','submodule','update','--init']
-            suproc = subprocess.Popen(
-                    sucmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(suproc,"submodule update",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-
-        ######################
-        # Check out the master branch of the submodule
-        # and pull the latest changes from upstream
-        ######################
-
-        if not abort:
-
-            if repo_name == 'dcppc-workshops':
-                submodule_dir_relative = os.path.join('docs','workshops')
-            else:
-                submodule_dir_relative = os.path.join('docs', repo_name)
-
-            submodule_dir = os.path.join(repo_dir, submodule_dir_relative)
-
-            subcocmd = ['git','checkout','master']
-            logging.debug("Running cmd: %s"%(' '.join(subcocmd)))
-            subcoproc = subprocess.Popen(
-                    subcocmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=submodule_dir
-            )
-            status_failed, status_file = record_and_check_output(subcoproc,"git checkout submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-            pullcmd = ['git','pull','origin','master']
-            logging.debug("Running cmd: %s"%(' '.join(pullcmd)))
-            pullproc = subprocess.Popen(
-                    pullcmd,
-                    stdout=PIPE, 
-                    stderr=PIPE, 
-                    cwd=submodule_dir
-            )
-            status_failed, status_file = record_and_check_output(pullproc,"git pull submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-
-        ######################
-        # Add commit push the new submodule
-        ######################
-
-        if not abort:
-
-            # Add the submodule
-            addcmd = ['git','add',submodule_dir_relative]
-            logging.debug("Running cmd: %s"%(' '.join(addcmd)))
-            addproc = subprocess.Popen(
-                    addcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(addproc,"git add submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-
-            # Commit the new submodule
-
-            commitcmd = ['git','commit',submodule_dir_relative,'-m',commit_msg]
-            logging.debug("Running cmd: %s"%(' '.join(commitcmd)))
-            commitproc = subprocess.Popen(
-                    commitcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(commitproc,"git commit submodule",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+        commitcmd = ['git','commit',submodule_dir_relative,'-m',commit_msg]
+        logging.debug("Running cmd: %s"%(' '.join(commitcmd)))
+        commitproc = subprocess.Popen(
+                commitcmd,
+                stdout=PIPE,
+                stderr=PIPE,
+                cwd=repo_dir
+        )
+        status_failed, status_file = record_and_check_output(commitproc,"git commit submodule",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
 
 
-            pushcmd = ['git','push','origin',branch_name]
-            logging.debug("Running cmd: %s"%(' '.join(pushcmd)))
-            pushproc = subprocess.Popen(
-                    pushcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(pushproc,"git push origin branch",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
+        pushcmd = ['git','push','origin',branch_name]
+        logging.debug("Running cmd: %s"%(' '.join(pushcmd)))
+        pushproc = subprocess.Popen(
+                pushcmd,
+                stdout=PIPE,
+                stderr=PIPE,
+                cwd=repo_dir
+        )
+        status_failed, status_file = record_and_check_output(pushproc,"git push origin branch",unique_filename)
+        if status_failed:
+            build_status = "fail"
+            abort = True
 
-
-        ######################
-        # New pull request
-        ######################
-
-        if not abort:
-
-            # Store the github token in an environment var for hub
-            os.environ['GITHUB_TOKEN'] = token
-
-            hubcmd = ['hub','pull-request',
-                    '-b','dcppc:master',
-                    '-h',branch_name,
-                    '-m',pr_msg]
-            logging.debug("Running cmd: %s"%(' '.join(hubcmd)))
-            hubproc = subprocess.Popen(
-                    hubcmd,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    cwd=repo_dir
-            )
-            status_failed, status_file = record_and_check_output(hubproc,"create pull request",unique_filename)
-            if status_failed:
-                build_status = "fail"
-                abort = True
-
-
-        ######################
-        # Clean up github token
-        ######################
-
-        os.environ['GITHUB_TOKEN'] = ""
-
-        # End open new PR workflow 
-        # ------------------------------------
-
-    # End private-www submodule update
-    # -----------------------------------------------
-
+    # End update submodule PR
+    # ------------------------------------
 
     if not abort:
         logging.info("private-www submodule PR succeeded for submodule %s"%(full_repo_name))


### PR DESCRIPTION
The fancy handling is not quite working as expected (old pull request name is updated, but then a new pull request is opened anyway??)